### PR TITLE
feat: add attest build provenance workflow

### DIFF
--- a/.github/workflows/build-provenance.yaml
+++ b/.github/workflows/build-provenance.yaml
@@ -1,0 +1,25 @@
+name: Build provenance
+
+on:
+  workflow_call:
+    inputs:
+      subject-checksums:
+        description: Subject checksums to attest; contents of a checksums file.
+        type: string
+        required: true
+
+permissions: {}
+
+jobs:
+  attest-build-provenance:
+    name: Attest build provenance
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write # to persist
+      id-token: write     # to sign
+    steps:
+      - name: Write subject checksums to a file
+        run: printf %s "${{ inputs.subject-checksums }}" >subject-checksums.txt
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: subject-checksums.txt


### PR DESCRIPTION
Use in https://github.com/UpCloudLtd/upcloud-cli/pull/655

Refs
- https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/increase-security-rating
- https://github.blog/enterprise-software/devsecops/enhance-build-security-and-reach-slsa-level-3-with-github-artifact-attestations/#achieving-slsa-level-3-compliance-with-github-artifact-attestations